### PR TITLE
Run e2e workflows on PR only

### DIFF
--- a/.github/workflows/compose-e2e.yml
+++ b/.github/workflows/compose-e2e.yml
@@ -15,22 +15,6 @@ on:
       - "scripts/e2e-smoke.sh"
       - "Makefile"
       - ".github/workflows/compose-e2e.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "Dockerfile"
-      - "go.mod"
-      - "go.sum"
-      - "**/*.go"
-      - "frontend/**"
-      - "dev/**"
-      - "configs/**"
-      - "docker-compose.yaml"
-      - "docker-compose.e2e.yaml"
-      - "scripts/e2e-smoke.sh"
-      - "Makefile"
-      - ".github/workflows/compose-e2e.yml"
 
 jobs:
   compose-e2e:

--- a/.github/workflows/helm-e2e.yml
+++ b/.github/workflows/helm-e2e.yml
@@ -13,20 +13,6 @@ on:
       - "scripts/e2e-smoke.sh"
       - "Makefile"
       - ".github/workflows/helm-e2e.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "Dockerfile"
-      - "go.mod"
-      - "go.sum"
-      - "**/*.go"
-      - "frontend/**"
-      - "deploy/chart/**"
-      - "scripts/helm-e2e-kind.sh"
-      - "scripts/e2e-smoke.sh"
-      - "Makefile"
-      - ".github/workflows/helm-e2e.yml"
 
 jobs:
   helm-e2e:


### PR DESCRIPTION
## Summary
- remove `push: main` from `compose-e2e.yml`
- remove `push: main` from `helm-e2e.yml`
- keep e2e checks as PR-only quality gates

## Why
- avoid rerunning the same e2e checks after merge
- keep post-merge work in `release.yml`

## Validation
- reviewed workflow diff

Closes #25
