### PR TITLE
Allow public API CORS requests without Referer

### DIFF
--- a/internal/httpapi/middleware.go
+++ b/internal/httpapi/middleware.go
@@ -8,32 +8,31 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func (h *Handler) allowedOrigin(c *gin.Context) {
-	origin := c.Request.Header.Get("Origin")
-	referer := c.Request.Header.Get("Referer")
-	if origin == "" || (c.Request.Method != http.MethodOptions && referer == "") {
-		c.JSON(http.StatusUnauthorized, gin.H{"status": "Unauthorized"})
-		c.Abort()
-		return
-	}
-
-	if !h.isAllowedOrigin(origin) {
-		c.JSON(http.StatusUnauthorized, gin.H{"status": "Unauthorized"})
-		c.Abort()
-		return
-	}
-
+func (h *Handler) publicCORS(c *gin.Context) {
 	h.setPublicCORS(c)
+
+	origin := strings.TrimSpace(c.Request.Header.Get("Origin"))
+	if origin == "" || !h.isAllowedOrigin(origin) {
+		c.JSON(http.StatusUnauthorized, gin.H{"status": "Unauthorized"})
+		c.Abort()
+		return
+	}
+
 	c.Next()
 }
 
 func (h *Handler) setPublicCORS(c *gin.Context) {
-	origin := c.Request.Header.Get("Origin")
+	addVary(c, "Origin", "Access-Control-Request-Headers", "Access-Control-Request-Method")
+
+	origin := strings.TrimSpace(c.Request.Header.Get("Origin"))
 	if origin == "" || !h.isAllowedOrigin(origin) {
 		return
 	}
 	c.Writer.Header().Set("Access-Control-Allow-Origin", origin)
-	c.Writer.Header().Set("Access-Control-Allow-Headers", "X-Firebase-AppCheck, X-Turnstile-AppCheck, X-Request-ID, Idempotency-Key, Content-Type")
+	c.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+	if requestedHeaders := strings.TrimSpace(c.Request.Header.Get("Access-Control-Request-Headers")); requestedHeaders != "" {
+		c.Writer.Header().Set("Access-Control-Allow-Headers", requestedHeaders)
+	}
 }
 
 func (h *Handler) setSchemaCORS(c *gin.Context) {
@@ -62,4 +61,34 @@ func (h *Handler) isAllowedOrigin(origin string) bool {
 	}
 	_, ok := allowed[origin]
 	return ok
+}
+
+func addVary(c *gin.Context, values ...string) {
+	header := c.Writer.Header()
+	current := header.Get("Vary")
+	parts := make([]string, 0, len(values)+1)
+	seen := map[string]struct{}{}
+	for _, part := range strings.Split(current, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		parts = append(parts, part)
+		seen[strings.ToLower(part)] = struct{}{}
+	}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		key := strings.ToLower(value)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		parts = append(parts, value)
+		seen[key] = struct{}{}
+	}
+	if len(parts) > 0 {
+		header.Set("Vary", strings.Join(parts, ", "))
+	}
 }

--- a/internal/httpapi/rate_limit.go
+++ b/internal/httpapi/rate_limit.go
@@ -88,12 +88,10 @@ func (h *Handler) rateLimitPublicAPI() gin.HandlerFunc {
 
 		key := publicRateLimitKey(c)
 		if !h.rateLimiter.Allow(key, h.cfg.Security.RateLimit.RequestsPerMinute) {
-			h.setPublicCORS(c)
 			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"status": "TooManyRequests"})
 			return
 		}
 		if h.failureRateLimiter.Limited(key, h.cfg.Security.RateLimit.FailureRequestsPerMinute) {
-			h.setPublicCORS(c)
 			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"status": "TooManyRequests"})
 			return
 		}

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -78,17 +78,16 @@ func NewRouter(cfg *config.Config, validator *requestvalidator.Engine, sender ma
 
 	api := root.Group("/api/v1")
 	api.Use(handler.auditPublicAPI())
-	api.Use(handler.rateLimitPublicAPI())
 	{
 		api.GET("/schema", handler.schema)
 		api.GET("/form-schema", handler.schema)
 
-		validate := api.Group("/validate").Use(handler.allowedOrigin)
+		validate := api.Group("/validate").Use(handler.publicCORS, handler.rateLimitPublicAPI())
 		validate.OPTIONS("", optionStatus)
 		validate.GET("", status("Ok"))
 		validate.POST("", handler.validatePost, status("Ok"))
 
-		sendmail := api.Group("/sendmail").Use(handler.allowedOrigin)
+		sendmail := api.Group("/sendmail").Use(handler.publicCORS, handler.rateLimitPublicAPI())
 		sendmail.OPTIONS("", optionStatus)
 		sendmail.GET("", status("Ok"))
 		sendmail.POST("", handler.validatePost, handler.sendmailPost)
@@ -119,6 +118,6 @@ func status(value string) gin.HandlerFunc {
 }
 
 func optionStatus(c *gin.Context) {
-	c.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST")
+	c.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 	c.JSON(http.StatusOK, gin.H{"status": "Ok", "version": version.Value()})
 }

--- a/internal/httpapi/router_test.go
+++ b/internal/httpapi/router_test.go
@@ -120,6 +120,99 @@ func TestValidatePostSuccessUsesOk(t *testing.T) {
 	}
 }
 
+func TestPublicAPIPreflightSuccess(t *testing.T) {
+	router := testRouter(t, &fakeSender{})
+	req := httptest.NewRequest(http.MethodOptions, "/api/v1/validate", nil)
+	req.Header.Set("Origin", "http://localhost:5173")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:5173" {
+		t.Fatalf("Access-Control-Allow-Origin = %q", got)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Methods"); !strings.Contains(got, "POST") {
+		t.Fatalf("Access-Control-Allow-Methods = %q, want POST", got)
+	}
+	assertVaryContains(t, rec, "Origin", "Access-Control-Request-Headers", "Access-Control-Request-Method")
+}
+
+func TestValidatePostAllowsValidOriginWithoutReferer(t *testing.T) {
+	router := testRouter(t, &fakeSender{})
+	req := validRequest(http.MethodPost, "/api/v1/validate")
+	req.Header.Del("Referer")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:5173" {
+		t.Fatalf("Access-Control-Allow-Origin = %q", got)
+	}
+}
+
+func TestValidationErrorIncludesCORSForValidOrigin(t *testing.T) {
+	router := testRouter(t, &fakeSender{})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/validate", bytes.NewBufferString(`{"name":"","email":"bad","message":""}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://localhost:5173")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:5173" {
+		t.Fatalf("Access-Control-Allow-Origin = %q", got)
+	}
+}
+
+func TestInvalidOriginIsUnauthorized(t *testing.T) {
+	router := testRouter(t, &fakeSender{})
+	req := validRequest(http.MethodPost, "/api/v1/validate")
+	req.Header.Set("Origin", "https://attacker.example")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("Access-Control-Allow-Origin = %q, want empty", got)
+	}
+	assertVaryContains(t, rec, "Origin", "Access-Control-Request-Headers", "Access-Control-Request-Method")
+}
+
+func TestPublicAPIPreflightReflectsCustomRequestHeaders(t *testing.T) {
+	router := testRouter(t, &fakeSender{})
+	req := httptest.NewRequest(http.MethodOptions, "/api/v1/sendmail", nil)
+	req.Header.Set("Origin", "http://localhost:5173")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	req.Header.Set("Access-Control-Request-Headers", "content-type, x-form-flow, x-client-trace-id")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:5173" {
+		t.Fatalf("Access-Control-Allow-Origin = %q", got)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Headers"); got != "content-type, x-form-flow, x-client-trace-id" {
+		t.Fatalf("Access-Control-Allow-Headers = %q", got)
+	}
+	assertVaryContains(t, rec, "Origin", "Access-Control-Request-Headers", "Access-Control-Request-Method")
+}
+
 func TestStatusEndpointIncludesVersion(t *testing.T) {
 	router := testRouter(t, &fakeSender{})
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -249,6 +342,9 @@ func TestSendmailIdempotencyKeyRejectsDifferentPayload(t *testing.T) {
 	if conflictRec.Code != http.StatusConflict {
 		t.Fatalf("conflict status = %d, body = %s", conflictRec.Code, conflictRec.Body.String())
 	}
+	if got := conflictRec.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:5173" {
+		t.Fatalf("Access-Control-Allow-Origin = %q", got)
+	}
 	if sender.count != 1 {
 		t.Fatalf("sender count = %d, want 1", sender.count)
 	}
@@ -276,6 +372,9 @@ func TestPublicAPIRateLimitRejectsExcessRequests(t *testing.T) {
 	router.ServeHTTP(secondRec, second)
 	if secondRec.Code != http.StatusTooManyRequests {
 		t.Fatalf("second status = %d, body = %s", secondRec.Code, secondRec.Body.String())
+	}
+	if got := secondRec.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:5173" {
+		t.Fatalf("Access-Control-Allow-Origin = %q", got)
 	}
 }
 
@@ -678,4 +777,20 @@ func dashboardTokenFromConfigJS(t *testing.T, router http.Handler) string {
 		t.Fatalf("dashboard token missing in config.js: %s", rec.Body.String())
 	}
 	return matches[1]
+}
+
+func assertVaryContains(t *testing.T, rec *httptest.ResponseRecorder, values ...string) {
+	t.Helper()
+	seen := map[string]struct{}{}
+	for _, part := range strings.Split(rec.Header().Get("Vary"), ",") {
+		part = strings.ToLower(strings.TrimSpace(part))
+		if part != "" {
+			seen[part] = struct{}{}
+		}
+	}
+	for _, value := range values {
+		if _, ok := seen[strings.ToLower(value)]; !ok {
+			t.Fatalf("Vary = %q, missing %q", rec.Header().Get("Vary"), value)
+		}
+	}
 }


### PR DESCRIPTION
### Summary
- English
  - Allow public API requests from configured Origins without requiring Referer.
  - Move CORS handling for validate and sendmail into dedicated middleware.
  - Reflect Access-Control-Request-Headers for preflight responses and preserve CORS headers on allowed-origin errors.
- Japanese
  - 設定済み Origin からの public API request で Referer を必須にしないようにします。
  - validate / sendmail の CORS 処理を dedicated middleware に寄せます。
  - preflight response では Access-Control-Request-Headers を反映し、許可済み Origin の error response にも CORS header を維持します。
### Why
- English
  - Frontend clients need real API error responses instead of opaque browser CORS failures.
  - Closes #33
- Japanese
  - frontend が不透明な CORS failure ではなく、実際の API error response を確認できるようにするためです。