### PR TITLE
Use request Origin for mail homepage URL

### DIFF
--- a/internal/httpapi/handlers.go
+++ b/internal/httpapi/handlers.go
@@ -56,7 +56,8 @@ func (h *Handler) sendmailPost(c *gin.Context) {
 		return
 	}
 
-	body, err := mail.RenderTemplate(h.cfg.Mail.TemplatePath, h.templateData(values))
+	homepageURL := h.homepageURLForRequest(c)
+	body, err := mail.RenderTemplate(h.cfg.Mail.TemplatePath, h.templateData(values, homepageURL))
 	if err != nil {
 		h.logger.Warn("failed to render mail template", zap.Error(err))
 		c.JSON(http.StatusBadRequest, gin.H{
@@ -142,11 +143,14 @@ func (h *Handler) valuesFromPayload(payload map[string]any) map[string]string {
 	return values
 }
 
-func (h *Handler) templateData(values map[string]string) map[string]any {
+func (h *Handler) templateData(values map[string]string, homepageURL string) map[string]any {
 	location, err := time.LoadLocation(h.cfg.Mail.Timezone)
 	if err != nil {
 		h.logger.Warn("failed to load configured mail timezone; falling back to UTC", zap.String("timezone", h.cfg.Mail.Timezone), zap.Error(err))
 		location = time.UTC
+	}
+	if strings.TrimSpace(homepageURL) == "" {
+		homepageURL = h.cfg.Mail.HomepageURL
 	}
 
 	fields := h.templateFields(values)
@@ -154,7 +158,7 @@ func (h *Handler) templateData(values map[string]string) map[string]any {
 		"fields":       fields,
 		"Fields":       fields,
 		"contact_name": h.cfg.Mail.ContactName,
-		"homepage_url": h.cfg.Mail.HomepageURL,
+		"homepage_url": homepageURL,
 		"submitted_at": time.Now().In(location).Format(h.cfg.Mail.SubmittedAtFormat),
 		"mail":         h.cfg.Mail,
 	}
@@ -166,8 +170,16 @@ func (h *Handler) templateData(values map[string]string) map[string]any {
 		data[legacyTemplateName(item.Name)] = item.Value
 	}
 	data["ContactName"] = h.cfg.Mail.ContactName
-	data["URL"] = h.cfg.Mail.HomepageURL
+	data["URL"] = homepageURL
 	return data
+}
+
+func (h *Handler) homepageURLForRequest(c *gin.Context) string {
+	origin := strings.TrimSpace(c.Request.Header.Get("Origin"))
+	if origin != "" && h.isAllowedOrigin(origin) {
+		return origin
+	}
+	return h.cfg.Mail.HomepageURL
 }
 
 func (h *Handler) templateFields(values map[string]string) []templateFieldItem {

--- a/internal/httpapi/router_test.go
+++ b/internal/httpapi/router_test.go
@@ -274,6 +274,30 @@ func TestSendmailPostRendersTemplateAndSends(t *testing.T) {
 	}
 }
 
+func TestSendmailPostUsesRequestOriginForHomepageURL(t *testing.T) {
+	cfg := config.Default()
+	cfg.Mail.HomepageURL = "https://configured.example"
+	cfg.Mail.TemplatePath = filepath.Join(t.TempDir(), "template.html")
+	if err := os.WriteFile(cfg.Mail.TemplatePath, []byte("{{ homepage_url }} {{ URL }}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	sender := &fakeSender{}
+	router := testRouterWithConfig(t, cfg, sender)
+	req := validRequest(http.MethodPost, "/api/v1/sendmail")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	want := "http://localhost:5173 http://localhost:5173"
+	if sender.message.Body != want {
+		t.Fatalf("rendered body = %q, want %q", sender.message.Body, want)
+	}
+}
+
 func TestSendmailRejectsHeaderInjectionSubject(t *testing.T) {
 	sender := &fakeSender{}
 	router := testRouter(t, sender)

--- a/internal/mail/templates/default_mail_template.html
+++ b/internal/mail/templates/default_mail_template.html
@@ -30,9 +30,9 @@
               </td>
             </tr>
             <tr>
-              <td style="padding:18px 28px;background:#f8fafc;border-top:1px solid #e5e9f0;color:#687587;font-size:12px;line-height:1.5;">
+              <td style="padding:20px 28px;background:#f8fafc;border-top:1px solid #e5e9f0;color:#687587;font-size:14px;line-height:1.6;">
                 Submitted at {{ submitted_at }}<br>
-                <a href="{{ homepage_url }}" style="color:#2563eb;text-decoration:none;">{{ homepage_url }}</a>
+                <a href="{{ homepage_url }}" style="color:#2563eb;text-decoration:none;font-size:15px;font-weight:600;">{{ homepage_url }}</a>
               </td>
             </tr>
           </table>


### PR DESCRIPTION
### Summary
- English
  - Use the allowed request Origin as the `homepage_url` and legacy `URL` values rendered in sendmail templates.
  - Increase the default mail template footer URL size for readability.
  - Closes #35.
- Japanese
  - sendmail template に描画する `homepage_url` と legacy `URL` に、許可済み request Origin を使うようにします。
  - default mail template の footer URL 表示を少し大きくして読みやすくします。
### Why
- English
  - Notification emails should identify the actual origin that submitted the form when multiple origins are allowed.
  - The existing footer URL display is too small.
- Japanese
  - 複数の origin を許可している場合、通知メールには実際にフォーム送信された origin を表示したいためです。
  - 既存の footer URL 表示が小さすぎるためです。